### PR TITLE
Use the separated gethrpctest binary for testing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,9 @@ To load a fixed state, clone the ethereum test repo as follows:
 
 Run the following go cli command to load the `RPC_API_Test` test:
 
-    $ geth --shh blocktest <pathToTheTestRepo>/lib/tests/BlockchainTests/bcRPC_API_Test.json RPC_API_Test rpc
+    $ gethrpctest --json <pathToTheTestRepo>/lib/tests/BlockchainTests/bcRPC_API_Test.json --test RPC_API_Test
 
 #### C++
-
 
 Run the following c++ cli command to load the `RPC_API_Test` test:
 


### PR DESCRIPTION
This PR just updates the readme to use the new RPC tester we've separated out a week or so ago instead of the built in blocktest command (which was dropped altogether).